### PR TITLE
Remove duplicated title in head

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -27,9 +27,15 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
 <!-- Site Title, Description, Author, and Favicon -->
-{{- with ($.Scratch.Get "Title") }}
-  <title>{{ . }} - {{ $.Site.Title }}</title>
-{{- end }}
+{{ if .IsHome }}
+    {{- with ($.Scratch.Get "Title") }}
+      <title>{{ . }}</title>
+    {{- end }}
+  {{ else }}
+    {{- with ($.Scratch.Get "Title") }}
+      <title>{{ . }} - {{ $.Site.Title }}</title>
+    {{- end }}
+{{ end }}
 {{- with ($.Scratch.Get "Description") }}
   <meta name="description" content="{{ . }}">
 {{- end }}


### PR DESCRIPTION
The duplicated title in head is quite annoying. This PR removes it. The fix is proudly stolen from https://github.com/halogenica/beautifulhugo/issues/397